### PR TITLE
Add checklist item "I have viewed my change in a web-browser"

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,6 +17,7 @@
 <!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->
 
 - [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
+- [ ] I have viewed my change in a web-browser
 - [ ] Linting and tests pass locally with my changes
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] I have added necessary documentation (if appropriate)


### PR DESCRIPTION
## Proposed changes

I often forget to simply open a web browser to confirm changes and assume they'll work because automated tests pass. Adding this checkbox will force me to check.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc

## Further comments

I guess it's not always necessary, e.g. this PR.